### PR TITLE
按照个人需求，做了一些小改动，希望能采纳~~

### DIFF
--- a/src/locales/en/_.json
+++ b/src/locales/en/_.json
@@ -187,7 +187,13 @@
     },
     "dropDetail": {
       "expectedAP": "Expected @:(item.AP_GAMEPLAY)",
-      "costPerformanceOfMission": " Cost Performance of Mission"
+      "costPerformanceOfMission": " Cost Performance of Mission",
+      "synthesizeCosts": "Synthesize Costs",
+      "needsOperators": "Needs Operators"
+    },
+    "todos": {
+      "tips": "Tips: Check the to-do items to complete the to-do tasks, and at the same time, the corresponding materials will be automatically deducted and the preset data will be modified",
+      "cannotFinished": "Lack of Material"
     }
   },
   "level": {

--- a/src/locales/en/_.json
+++ b/src/locales/en/_.json
@@ -41,7 +41,8 @@
     "backup": "Backup",
     "restore": "Restore",
     "mission": "Mission",
-    "times": "Times"
+    "times": "Times",
+    "todo": "Todos"
   },
   "app": {
     "title": "Arknights Toolbox",

--- a/src/locales/zh/_.json
+++ b/src/locales/zh/_.json
@@ -41,7 +41,8 @@
     "backup": "备份",
     "restore": "恢复",
     "mission": "关卡",
-    "times": "次数"
+    "times": "次数",
+    "todo": "待办"
   },
   "app": {
     "title": "明日方舟工具箱"

--- a/src/locales/zh/_.json
+++ b/src/locales/zh/_.json
@@ -181,7 +181,13 @@
     },
     "dropDetail": {
       "expectedAP": "消耗@:(item.AP_GAMEPLAY)",
-      "costPerformanceOfMission": "@:(common.mission)性价比"
+      "costPerformanceOfMission": "@:(common.mission)性价比",
+      "synthesizeCosts": "合成消耗",
+      "needsOperators": "需求干员"
+    },
+    "todos": {
+      "tips": "提示：勾选对应待办事项，即可完成待办任务，同时会自动扣除对应材料，修改预设数据",
+      "cannotFinished": "材料不足"
     }
   },
   "base": {

--- a/src/views/Material.vue
+++ b/src/views/Material.vue
@@ -88,7 +88,7 @@
               <div class="card-triangle-small" v-theme-class="color[materialsTable[materialName].rare]"></div>
               <div class="mdui-card-header" :name="materialName">
                 <!-- 图片 -->
-                <div class="mdui-card-header-avatar mdui-valign no-sl" :class="{ pointer: l.size(materialsTable[materialName].drop) > 0 }" @click="l.size(materialsTable[materialName].drop) > 0 ? showDropDetail(materialsTable[materialName]) : false">
+                <div class="mdui-card-header-avatar mdui-valign no-sl" :class="{ pointer: l.size(materialsTable[materialName].drop) > 0 }" @click="showDropDetail(materialsTable[materialName])">
                   <arkn-item-t :t="materialsTable[materialName].rare" />
                   <img class="material-image no-pe" :src="$root.materialImage(materialsTable[materialName].name)" crossorigin="anonymous" />
                   <div class="material-simple-name mdui-text-truncate" v-theme-class="inputs[materialName].need > 0 ? $root.color.pinkText : []">{{ $t(`material.${materialName}`) }}</div>
@@ -123,7 +123,7 @@
               <div class="card-triangle" v-theme-class="color[rareNum + 1 - i]"></div>
               <div class="mdui-card-header" :name="material.name" :mdui-tooltip="$root.smallScreen ? false : `{content:'${madeofTooltips[material.name]}',position:'top'}`">
                 <!-- 图片 -->
-                <div class="mdui-card-header-avatar mdui-valign no-sl">
+                <div class="mdui-card-header-avatar mdui-valign no-sl" @click="showDropDetail(materialsTable[material.name])">
                   <arkn-item-t :t="rareNum + 1 - i" />
                   <img class="material-image no-pe" :src="$root.materialImage(material.name)" crossorigin="anonymous" />
                 </div>
@@ -131,7 +131,8 @@
                 <div class="mdui-card-header-title no-sl" v-theme-class="inputs[material.name].need > 0 ? $root.color.pinkText : []">
                   <div class="material-name-wrap mdui-valign">
                     <div class="mdui-text-truncate">{{ $t(`material.${material.name}`) }}</div>
-                    <button v-if="showSyntBtn(material)" @click="synthesize(material.name)" class="synt-btn mdui-btn mdui-ripple mdui-btn-dense small-btn mdui-p-x-1 mdui-m-l-05" v-theme-class="$root.color.pinkText">{{$t('common.synthesize')}}</button>
+                    <button v-if="showSyntBtn(material)" @click="synthesize(material.name)" class="synt-btn mdui-btn mdui-ripple mdui-btn-dense small-btn mdui-p-x-1 mdui-m-l-05" v-theme-class="$root.color.pinkText">{{$t('common.synthesize')}} all</button>
+                    <button v-if="showSyntBtn(material)" @click="synthesize(material.name, 1)" class="synt-btn mdui-btn mdui-ripple mdui-btn-dense small-btn mdui-p-x-1 mdui-m-l-05" v-theme-class="$root.color.pinkText">{{$t('common.synthesize')}} 1</button>
                   </div>
                   <p v-if="$root.smallScreen" class="mdui-m-y-0 mdui-text-color-theme-disabled mdui-text-truncate" style="font-size:12px;font-weight:400">{{ madeofTooltips[material.name] }}</p>
                 </div>
@@ -921,10 +922,10 @@ export default {
       }
       return width;
     },
-    synthesize(name) {
+    synthesize(name, num) {
       if (!this.synthesizable[name]) return;
       const { madeof } = this.materialsTable[name];
-      const times = Math.min(
+      const times = num || Math.min(
         _.sum(this.gaps[name]),
         ..._.map(madeof, (num, m) => Math.floor(this.inputsInt[m].have / num))
       );


### PR DESCRIPTION
### 需求场景
1. 喜欢简洁模式，可以按照仓库顺序，录入材料比较方便，但是由于空间不够，无法操作合成（可以切换到普通模式合成，但是一切换顺序就变了。）。
2. 合成操作强制全部合成不太方便（很多时候不需要合成太多，只需要合成需要的数量）。
3. 如果预设干员太多，无法明了的知晓具体某个干员需求的是哪个材料（可以查看wiki，但是不太方便）。
4. 如果预设材料数量达到，游戏中操作技能升级消耗材料后，每次都需要重新录入，不太方便。

> 后两条可能比较偏私人，因为个人比较喜欢一次预设一批想要练的干员，然后一个个排着号精二专精。毕竟刷图规划，如果预设需求不多的话，其实也不太需要规划，数量越大，相对性价比才更优。

###  更新内容
- 掉落弹框内增加 合成消耗，对应需求干员 ，需求已有仍需数据，以及合成操作按钮显示。
- 增加单个合成按钮选项
- 增加待办任务项，基于预设数据。具体功能操作为：
   - 点击干员，弹出待办项目弹框，列出选中预设对应的具体升级任务列表
   - 任务信息包含任务名称，需求材料数/已有材料数。
   - 勾选任务框，可以完成任务。同时扣除对应材料，变更对应预设数据。
   - 同类任务只能按照顺序一级级完成。