### PR TITLE
[i18n] 修正繁體中文翻譯

### DIFF
--- a/src/data/contributors.json
+++ b/src/data/contributors.json
@@ -27,7 +27,7 @@
   },
   "contribution": ["tsuk1ko", "viewweiwu", "doir"],
   "translation": {
-    "繁体中文": ["ButterCatz"],
+    "繁體中文": ["ButterCatz"],
     "English": ["tsuk1ko", "doir"],
     "日本語": ["tsuk1ko", "konayuki_kh", "viewweiwu"]
   }

--- a/src/store/lang.js
+++ b/src/store/lang.js
@@ -31,7 +31,7 @@ const locales = [
   },
   {
     short: 'tw',
-    long: '繁体中文',
+    long: '繁體中文',
   },
   {
     short: 'us',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -29,7 +29,8 @@
         >Welcome to submit <a href="https://github.com/Tsuk1ko/arknights-toolbox/issues" target="_blank">issue</a> or
         pull request if you have good ideas, suggestions, or find some bugs.</p
       >
-      <p v-if="$root.localeZH">觉得好用的话记得向朋友推荐一下呀~</p>
+      <p v-if="$root.localeCN">觉得好用的话记得向朋友推荐一下呀~</p>
+      <p v-else-if="$root.localeIs('tw')">覺得好用的話記得跟朋友推薦一下呀~</p>
       <p v-else>If you think this toolbox helps you well, just recommend to your friends!</p>
       <h2>{{ $t('common.setting') }}</h2>
       <div class="no-sl">


### PR DESCRIPTION
## 改動

- 把 "繁体中文" 改成 "繁體中文"
- 首頁裡只有一句沒有對應到繁中，爬了一下 log 應該是在 e740a32 Home.vue 的部分漏改了，於是就按照前後文補上去了